### PR TITLE
Hide Widget components

### DIFF
--- a/address/widgets.py
+++ b/address/widgets.py
@@ -76,7 +76,7 @@ class AddressWidget(forms.TextInput):
         elems = [super(AddressWidget, self).render(name, ad.get('formatted', None), attrs, **kwargs)]
 
         # Now add the hidden fields.
-        elems.append('<div id="%s_components">' % name)
+        elems.append('<div id="%s_components" style="display: none;">' % name)
         for com in self.components:
             elems.append('<input type="hidden" name="%s_%s" data-geo="%s" value="%s" />' % (
                 name, com[0], com[1], ad.get(com[0], ''))

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 
 from setuptools import find_packages, setup
 
-version = '0.2.0'
+version = '0.2.1'
 
 if sys.argv[-1] == 'tag':
     print("Tagging the version on github:")


### PR DESCRIPTION
Hide the Widget Components via CSS so the Django admin UI matches
standards.